### PR TITLE
New Filtering Function To Remove Specified Markers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 var usfmToJson = require('./src/js/usfmToJson.js').usfmToJSON;
 var jsonToUsfm = require('./src/js/jsonToUsfm.js').jsonToUSFM;
 var getHeaders = require('./src/js/getHeaders.js');
+var filter = require('./src/js/filter');
 
 exports.toJSON = usfmToJson;
 exports.toUSFM = jsonToUsfm;
 exports.getHeaders = getHeaders;
+exports.removeMarker = filter.removeMarker;

--- a/src/js/filter.js
+++ b/src/js/filter.js
@@ -1,0 +1,12 @@
+
+/**
+ * @param {string} string - The string to remove specfic marker from
+ * @param {string} type - The type of marker to remove i.e. f | h
+ * Note: if no type is given all markers are removed
+ */
+module.exports.removeMarker = function (string = '', type) {
+  var typeRegex = type ? '\\' + type : '\\';
+  var regString = '\\' + typeRegex + '\\w*' + '\\**|(\\s\\+(?=(\\s)))';
+  var regex = new RegExp(regString, 'g')
+  return string.replace(regex, '');
+}

--- a/tests/d.removeMarker.js
+++ b/tests/d.removeMarker.js
@@ -1,0 +1,60 @@
+const removeMarker = require('../index').removeMarker;
+const expect = require('chai').expect;
+const fs = require('fs');
+
+describe('removeMarker', function () {
+  it('should remove all extra tags from a string', function (done) {
+    let randomMarkerString = fs.readFileSync('./tests/static/footnotes.json').toString();
+    expect(randomMarkerString).to.include('\\f');
+    expect(randomMarkerString).to.include('\\q');
+    let randomMarkerJSON = JSON.parse(randomMarkerString);
+    var resultString = '';
+    for (var verse in randomMarkerJSON) {
+      let regString = randomMarkerJSON[verse];
+      //Removing all markers
+      let fixedString = removeMarker(regString);
+      resultString += fixedString + '\n';
+    }
+    expect(resultString).to.not.include('\\f');
+    expect(resultString).to.not.include('\\q');
+    expect(resultString).to.not.include('\\');
+    expect(resultString).to.include('I pray that the eyes  of your heart may be enlightened');
+    done()
+  });
+  it('should remove f tags from a string', function (done) {
+    let randomMarkerString = fs.readFileSync('./tests/static/footnotes.json').toString();
+    expect(randomMarkerString).to.include('\\f');
+    expect(randomMarkerString).to.include('\\q');
+    let randomMarkerJSON = JSON.parse(randomMarkerString);
+    var resultString = '';
+    for (var verse in randomMarkerJSON) {
+      let regString = randomMarkerJSON[verse];
+      //Removing all markers
+      let fixedString = removeMarker(regString, 'f');
+      resultString += fixedString + '\n';
+    }
+    expect(resultString).to.not.include('\\f');
+    expect(resultString).to.include('\\q');
+    expect(resultString).to.include('\\');
+    expect(resultString).to.include('I pray that the eyes  of your heart may be enlightened');
+    done()
+  });
+  it('should remove q tags from a string', function (done) {
+    let randomMarkerString = fs.readFileSync('./tests/static/footnotes.json').toString();
+    expect(randomMarkerString).to.include('\\f');
+    expect(randomMarkerString).to.include('\\q');
+    let randomMarkerJSON = JSON.parse(randomMarkerString);
+    var resultString = '';
+    for (var verse in randomMarkerJSON) {
+      let regString = randomMarkerJSON[verse];
+      //Removing all markers
+      let fixedString = removeMarker(regString, 'q');
+      resultString += fixedString + '\n';
+    }
+    expect(resultString).to.include('\\f');
+    expect(resultString).to.not.include('\\q');
+    expect(resultString).to.include('\\');
+    expect(resultString).to.include('I pray that the eyes \\f of your heart may be enlightened,');
+    done()
+  });
+});


### PR DESCRIPTION
#### This pull request addresses:
This PR utilizes the new filtering function in the usfm module to remove extra, unneeded tags.

#### How to test this pull request:
Checkout branch ```enhancement/jay/filter-footnotes/1941```
on Scripture Pane, and Verse Check (this is assuming the usfm latetest module with the filtering function has already been merged with develop)
and open an eph book on tN and find the check for 1:1 and ensure there are no footnotes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/usfm-js/10)
<!-- Reviewable:end -->
