### PR TITLE
Handling More Use Cases For USFM Chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var usfmToJson = require('./src/js/usfmToJson.js').usfmToJSON;
 var jsonToUsfm = require('./src/js/jsonToUsfm.js').jsonToUSFM;
 var filter = require('./src/js/filter');
-const fs = require('fs');
 
 exports.toJSON = usfmToJson;
 exports.toUSFM = jsonToUsfm;
 exports.removeMarker = filter.removeMarker;
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-js",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "A small library that provides functions to convert usfm to JSON and vice-versa",
   "main": "index.js",
   "scripts": {

--- a/src/js/jsonToUsfm.js
+++ b/src/js/jsonToUsfm.js
@@ -80,5 +80,15 @@ exports.jsonToUSFM = function(json) {
       lines = lines.concat(chapterLines);
     });
   }
+  if (json.verses) {
+    const verseNumbers = Object.keys(json.verses);
+    verseNumbers.forEach(function(verseNumber) {
+      const verseObject = json.verses[verseNumber];
+      const verseLines = exports.generateVerseLines(
+        verseNumber, verseObject
+      );
+      lines = lines.concat(verseLines);
+    });
+  }
   return lines.join('\n');
 };

--- a/tests/c.usfm-chunks-parser.js
+++ b/tests/c.usfm-chunks-parser.js
@@ -11,17 +11,16 @@ var converted;
 describe('Chunks - usfmToJson', function() {
   it('should return expected json data from usfm string', function() {
     const usfm = fs.readFileSync(usfmPath, 'UTF-8').toString();
-    converted = usfmToJson(usfm, {chapter: 1});
+    converted = usfmToJson(usfm, {chunk: true});
     assert.isObject(converted);
-    assert.isObject(converted.headers);
-    assert.isObject(converted.chapters);
-    const chapter1 = converted.chapters[1];
-    assert.isObject(chapter1);
-    const verse13 = chapter1[13];
+    assert.isObject(converted.verses);
+    const verses = converted.verses;
+    assert.isObject(verses);
+    const verse13 = verses[13];
     assert.isArray(verse13);
-    const verse14 = chapter1[14];
+    const verse14 = verses[14];
     assert.isArray(verse14);
-    const verse15 = chapter1[15];
+    const verse15 = verses[15];
     assert.isArray(verse15);
     const text = verse13[0];
     assert.isString(text);
@@ -34,7 +33,7 @@ describe('Chunks - jsonToUsfm', function() {
   it('should take in a JSON object, and convert it to a string', function() {
     let backToString = jsonToUsfm(converted);
     assert.isString(backToString);
-    assert.isTrue(backToString.length >= 250);
-    assert.isTrue(backToString.length <= 255);
+    expect(backToString).to.include('\\v 14 But I expect to see you soon, and we will speak face to face');
+    expect(backToString).to.include('\\v 15 May peace be with you. The friends greet you. Greet the friends by name.');
   });
 });


### PR DESCRIPTION
There are use cases for usfm -> JSON and JSON -> usfm where  the chapter is unknown.
This PR modifies the params take a key ```chunk``` which if is set will output an object in the .verses property of the ```USFMJSON object``` everthing else will stay the same if the params.chunk flag is not set.

This PR also updates tests for the new use case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/usfm-js/15)
<!-- Reviewable:end -->
