### PR TITLE
Bugfix #3485/Text following paragraph marker is lost

### DIFF
--- a/__tests__/resources/inline_paragraphs.json
+++ b/__tests__/resources/inline_paragraphs.json
@@ -1,0 +1,11 @@
+{
+  "headers": {},
+  "chapters": {
+    "2": {
+      "8": [
+        "You put everything in subjection under his feet.\"",
+        "For it was to him that God has subjected all things. He did not leave anything not subjected to him. But now we do not yet see everything subjected to him."
+      ]
+    }
+  }
+}

--- a/__tests__/resources/inline_paragraphs.usfm
+++ b/__tests__/resources/inline_paragraphs.usfm
@@ -1,0 +1,4 @@
+\c 2
+\q
+\v 8 You put everything in subjection under his feet."
+\p For it was to him that God has subjected all things. He did not leave anything not subjected to him. But now we do not yet see everything subjected to him.

--- a/__tests__/resources/inline_paragraphs_chunk.json
+++ b/__tests__/resources/inline_paragraphs_chunk.json
@@ -1,0 +1,10 @@
+{
+  "headers": {},
+  "chapters": {},
+  "verses": {
+    "8": [
+      "You put everything in subjection under his feet.\"",
+      "For it was to him that God has subjected all things. He did not leave anything not subjected to him. But now we do not yet see everything subjected to him."
+    ]
+  }
+}

--- a/__tests__/resources/inline_paragraphs_chunk.usfm
+++ b/__tests__/resources/inline_paragraphs_chunk.usfm
@@ -1,0 +1,3 @@
+\q
+\v 8 You put everything in subjection under his feet."
+\p For it was to him that God has subjected all things. He did not leave anything not subjected to him. But now we do not yet see everything subjected to him.

--- a/__tests__/usfmToJson.test.js
+++ b/__tests__/usfmToJson.test.js
@@ -50,3 +50,15 @@ it('handles quotes in chunk', () => {
 it('handles quotes', () => {
   generateTest('quotes');
 });
+
+it('handles quotes in chunk', () => {
+  generateTest('quotes_chunk', {chunk: true});
+});
+
+it('handles inline paragraphs', () => {
+  generateTest('inline_paragraphs');
+});
+
+it('handles inline paragraphs in chunk', () => {
+  generateTest('inline_paragraphs_chunk', {chunk: true});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-js",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.17.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-js",
-  "version": "1.0.0-beta.17.1",
+  "version": "1.0.0-beta.17.2",
   "description": "A small library that provides functions to convert usfm to JSON and vice-versa",
   "main": "lib/index.js",
   "scripts": {

--- a/src/js/usfmToJson.js
+++ b/src/js/usfmToJson.js
@@ -183,7 +183,9 @@ export const usfmToJSON = (usfm, params = {}) => {
         } else if ((currentChapter || params.chunk) && currentVerse &&
                       marker.type) { // if we already have started chapter:verse or a verse chunk,
                                       // then add USFM contect we care about
-          if (marker.content && (marker.type[0] === 'q')) { // add quote content (\q, \q1, ...)
+          if (marker.content &&
+                ((marker.type[0] === 'q') || // add quote content (\q, \q1, ...)
+                (marker.type === 'p'))) { // inline paragraphs
             if (params.chunk) {
               verses[currentVerse].push(marker.content);
             } else {


### PR DESCRIPTION
Fix for problem that paragraph markers with text on same line are ignored.  This fix preserves the text.

Needs to be uploaded NPM as 1.0.0-beta.17.2 to test and tC updated to use that version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/usfm-js/25)
<!-- Reviewable:end -->
