### PR TITLE
Bugfix 4921/Fix footnote removal

### DIFF
--- a/__tests__/removeMarker.test.js
+++ b/__tests__/removeMarker.test.js
@@ -3,7 +3,6 @@ import {removeMarker} from '../src/js/filter';
 
 const input = '...Christ\\q Jesus. \\f + \\ft Some early versions omit, \\fqa in Ephesus, \\fqa* but this expression is probably in Paul\'s original letter.\\f*';
 
-
 /**
  * Generator for testing usfm filtering
  * @param {string} name - the name of the test files to use. e.g. `valid` will test `valid.usfm` to `valid.json`
@@ -27,6 +26,34 @@ it('removes all extra tags', () => {
 it('removes f tags', () => {
   const expected = '...Christ\\q Jesus. ';
   const output = removeMarker(input, 'f');
+  expect(output).toEqual(expected);
+});
+
+it('removes f tags with following s5 tag', () => {
+  const input = "He even tried to desecrate the temple, so we arrested him.\\f + \\ft Some ancient copies add, \\fqa \"We wanted to judge him according to our law \\fqa* . \\f*\\s5";
+  const expected = 'He even tried to desecrate the temple, so we arrested him.\\s5';
+  const output = removeMarker(input, 'f');
+  expect(output).toEqual(expected);
+});
+
+it('removes f and s5 tags', () => {
+  const input = "He even tried to desecrate the temple, so we arrested him.\\f + \\ft Some ancient copies add, \\fqa \"We wanted to judge him according to our law \\fqa* . \\f*\\s5";
+  const expected = 'He even tried to desecrate the temple, so we arrested him.';
+  const output = removeMarker(input, ['f', 's(\\d)?']);
+  expect(output).toEqual(expected);
+});
+
+it('removes f tags with following p tag', () => {
+  const input = "\\f + \\ft Acts 28:29—Some ancient copies have verse 29: \\fqa When he had said these things, the Jews went away. They were having a great dispute among themselves \\fqa* . \\f*\\p";
+  const expected = '\\p';
+  const output = removeMarker(input, 'f');
+  expect(output).toEqual(expected);
+});
+
+it('removes f and p tags', () => {
+  const input = "\\f + \\ft Acts 28:29—Some ancient copies have verse 29: \\fqa When he had said these things, the Jews went away. They were having a great dispute among themselves \\fqa* . \\f*\\p";
+  const expected = '';
+  const output = removeMarker(input, ['f', 'p(\\d)?']);
   expect(output).toEqual(expected);
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usfm-js",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A small library that provides functions to convert usfm to JSON and vice-versa",
   "main": "lib/index.js",
   "scripts": {

--- a/src/js/filter.js
+++ b/src/js/filter.js
@@ -7,8 +7,7 @@
 export const removeMarker = (string = '', types) => {
   if (typeof (types) === 'string') types = [types];
   if (!types || types.includes('f')) {
-    const regString = '\\\\f[\\S\\s]*\\\\f[^a-z|A-Z|0-9|\\s]*';
-    const regex = new RegExp(regString, 'g');
+    const regex = new RegExp(/\\f[\S\s]*\\f[^a-z|A-Z|0-9|\s|\\]*/g);
     string = string.replace(regex, '');
   }
   if (!types || types.includes('q')) {


### PR DESCRIPTION
Fix footnote regex in removeMarker() to handle markers immediately following.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/usfm-js/40)
<!-- Reviewable:end -->
